### PR TITLE
Run and Compile Applescript

### DIFF
--- a/building/applescript/applescript [default]/build.sh
+++ b/building/applescript/applescript [default]/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+osacompile -o "$CHOC_FILENAME_NOEXT.scpt" "$CHOC_FILE" && mkdir -p "$CHOC_BUILD_DIR" && mv "$CHOC_FILENAME_NOEXT.scpt" "$CHOC_BUILD_DIR"

--- a/building/applescript/applescript [default]/run.sh
+++ b/building/applescript/applescript [default]/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd "$CHOC_RUN_DIRECTORY" && osascript "$CHOC_FILE"


### PR DESCRIPTION
This PR adds Run and Build/Compile for Applescript.

Since `osacompile` always writes to the project directory (and doesn't know a target directory argument), the compiled `.scpt` file will be complied to the project directory first, and then moved to the build directory.
